### PR TITLE
Add colored link-type feedback for deduplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +287,7 @@ dependencies = [
  "bincode",
  "blake3",
  "clap",
+ "colored",
  "crossbeam",
  "indicatif",
  "jwalk",
@@ -325,6 +336,12 @@ dependencies = [
  "crossbeam",
  "rayon",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 blake3 = "1"
 bincode = "1"
 clap = { version = "4", features = ["derive"] }
+colored = "2"
 crossbeam = "0.8"
 indicatif = "0.17"
 jwalk = "0.8"

--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -1,9 +1,15 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
-pub fn replace_with_link(master: &Path, target: &Path) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkType {
+    Reflink,
+    HardLink,
+}
+
+pub fn replace_with_link(master: &Path, target: &Path) -> Result<Option<LinkType>> {
     if master == target {
-        return Ok(());
+        return Ok(None);
     }
 
     let mut temp = target.to_path_buf();
@@ -15,7 +21,7 @@ pub fn replace_with_link(master: &Path, target: &Path) -> Result<()> {
     match reflink::reflink(master, &temp) {
         Ok(_) => {
             std::fs::rename(&temp, target).with_context(|| "replace target with reflink")?;
-            Ok(())
+            Ok(Some(LinkType::Reflink))
         }
         Err(_) => {
             if temp.exists() {
@@ -23,7 +29,7 @@ pub fn replace_with_link(master: &Path, target: &Path) -> Result<()> {
             }
             std::fs::hard_link(master, &temp).with_context(|| "create hard link")?;
             std::fs::rename(&temp, target).with_context(|| "replace target with hard link")?;
-            Ok(())
+            Ok(Some(LinkType::HardLink))
         }
     }
 }


### PR DESCRIPTION
1. Add colored dependency for ANSI terminal colors.
2. Introduce LinkType and return it from replace_with_link.
3. Print colored, link-type-specific output in dedupe_groups (Reflink green, HardLink yellow).