### PR TITLE
fix: prevent redundant deduplication via inode tracking and temp filtering

### DIFF
--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -1,10 +1,36 @@
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LinkType {
     Reflink,
     HardLink,
+}
+
+struct TempCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if self.path.exists() {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
 }
 
 pub fn replace_with_link(master: &Path, target: &Path) -> Result<Option<LinkType>> {
@@ -18,9 +44,12 @@ pub fn replace_with_link(master: &Path, target: &Path) -> Result<Option<LinkType
         std::fs::remove_file(&temp).with_context(|| "remove existing temp file")?;
     }
 
+    let mut cleanup = TempCleanup::new(temp.clone());
+
     match reflink::reflink(master, &temp) {
         Ok(_) => {
             std::fs::rename(&temp, target).with_context(|| "replace target with reflink")?;
+            cleanup.disarm();
             Ok(Some(LinkType::Reflink))
         }
         Err(_) => {
@@ -29,6 +58,7 @@ pub fn replace_with_link(master: &Path, target: &Path) -> Result<Option<LinkType
             }
             std::fs::hard_link(master, &temp).with_context(|| "create hard link")?;
             std::fs::rename(&temp, target).with_context(|| "replace target with hard link")?;
+            cleanup.disarm();
             Ok(Some(LinkType::HardLink))
         }
     }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -14,6 +14,13 @@ pub fn group_by_size(root: &Path) -> Result<HashMap<u64, Vec<PathBuf>>> {
         if !entry.file_type().is_file() {
             continue;
         }
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .ends_with(".imprint_tmp")
+        {
+            continue;
+        }
         let metadata = match entry.metadata() {
             Ok(metadata) => metadata,
             Err(_) => continue,


### PR DESCRIPTION
1. Added vaulted inode tracking in ```state.rs``` and ensured tables are initialized.
2. Skipped ```.imprint_tmp``` entries during scanning in scanner.rs.
3. Short-circuited hashing for vaulted inodes and skipped temp-file logging in main.rs.
4. Made temp-file cleanup robust in ```dedupe.rs``` and marked hard-linked inodes as vaulted in ```main.rs```.

Fixes #11 