### PR TITLE
feat(hasher): implement sparse-aware sampling for Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "crossbeam",
  "indicatif",
  "jwalk",
+ "nix",
  "rayon",
  "redb",
  "reflink",
@@ -97,6 +98,12 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
@@ -120,9 +127,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -136,9 +143,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -146,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -170,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -345,9 +352,20 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "number_prefix"
@@ -480,9 +498,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -511,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,12 @@ colored = "2"
 crossbeam = "0.8"
 indicatif = "0.17"
 jwalk = "0.8"
+nix = { version = "0.27", features = ["ioctl"], optional = true }
 rayon = "1"
 redb = "2"
 reflink = "0.1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = { version = "0.27", features = ["ioctl"] }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -21,7 +21,8 @@ pub fn sparse_hash(path: &Path, size: u64) -> Result<Hash> {
     read_at(&mut file, 0, &mut buffer)?;
     hasher.update(&buffer);
 
-    let middle = (size / 2).saturating_sub((SPARSE_CHUNK / 2) as u64);
+    let mid_target = (size / 2).saturating_sub((SPARSE_CHUNK / 2) as u64);
+    let middle = adjust_offset_for_sparse(&file, mid_target, size);
     read_at(&mut file, middle, &mut buffer)?;
     hasher.update(&buffer);
 
@@ -53,4 +54,64 @@ fn read_at(file: &mut File, offset: u64, buffer: &mut [u8]) -> Result<()> {
         .with_context(|| "seek file")?;
     file.read_exact(buffer).with_context(|| "read sparse chunk")?;
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn adjust_offset_for_sparse(file: &File, target: u64, _file_size: u64) -> u64 {
+    use nix::ioctl_readwrite;
+    use std::mem;
+    use std::os::unix::io::AsRawFd;
+
+    #[repr(C)]
+    struct FiemapExtent {
+        fe_logical: u64,
+        fe_physical: u64,
+        fe_length: u64,
+        fe_flags: u32,
+        fe_reserved: u32,
+    }
+
+    #[repr(C)]
+    struct Fiemap {
+        fm_start: u64,
+        fm_length: u64,
+        fm_flags: u32,
+        fm_mapped_extents: u32,
+        fm_extent_count: u32,
+        fm_reserved: u32,
+        fm_extents: [FiemapExtent; 32],
+    }
+
+    ioctl_readwrite!(fiemap, b'f', 11, Fiemap);
+
+    let fd = file.as_raw_fd();
+    let mut fiemap_data: Fiemap = unsafe { mem::zeroed() };
+    fiemap_data.fm_start = target;
+    fiemap_data.fm_length = u64::MAX;
+    fiemap_data.fm_extent_count = 32;
+
+    if unsafe { fiemap(fd, &mut fiemap_data).is_ok() } {
+        let mapped = fiemap_data.fm_mapped_extents as usize;
+        if mapped > 0 {
+            for i in 0..mapped {
+                let extent = &fiemap_data.fm_extents[i];
+                let extent_start = extent.fe_logical;
+                let extent_end = extent_start + extent.fe_length;
+
+                if target >= extent_start && target < extent_end {
+                    return target;
+                }
+                if extent_start > target {
+                    return extent_start;
+                }
+            }
+        }
+    }
+
+    target
+}
+
+#[cfg(not(target_os = "linux"))]
+fn adjust_offset_for_sparse(_file: &File, target: u64, _file_size: u64) -> u64 {
+    target
 }


### PR DESCRIPTION
Fixes #5 

- Add detection for file holes using FIEMAP ioctl on Linux systems.
- Shift sparse hash middle-sample from unallocated blocks to the nearest data extent.
- Prevent false positives in Tier 2 hashing for large sparse files.
- Maintain existing sampling logic as a fallback for non-Linux platforms.