### PR TITLE
feat(cli): upgrade clap help text and command documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 edition = "2024"
 description = "A speed-first local data deduplication engine using tiered BLAKE3 hashing."
 license = "Apache-2.0"
-authors = ["Rakshat Pratap Singh"]
+authors = ["Rakshat28"]
 repository = ""
 readme = "README.md"
 keywords = ["deduplication", "storage", "nvme", "blake3"]
 categories = ["command-line-utilities", "filesystem"]
 
 [[bin]]
-name = "imprint"
+name = "bdstorage"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
Fixes #10 
- Update CLI name reference to `bdstorage`.
- Add ```long_about``` to detail the Tiered Hashing philosophy.
- Add custom ```help_template``` to display default storage paths (~/.bdstorage).
- Refactor subcommands (scan, dedupe, restore) to use idiomatic Rust doc comments (///).
- Refactor ```--paranoid``` and ```--dry-run``` flags to use doc comments instead of inline macros.
- Enable automatic ```-V``` / ```--version``` flags tied to Cargo.toml.