### PR TITLE
integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test -- --test-threads=1
+
+      - name: Build release
+        run: cargo build --release
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Generate coverage
+        run: cargo tarpaulin --out Xml --timeout 300 -- --test-threads=1
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./cobertura.xml
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup Rust caching
+        uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,10 +80,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bdstorage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "bincode",
  "blake3",
  "clap",
@@ -84,11 +115,14 @@ dependencies = [
  "indicatif",
  "jwalk",
  "nix",
+ "predicates",
  "rayon",
  "redb",
  "reflink",
  "serde",
+ "tempfile",
  "thiserror",
+ "walkdir",
  "xattr",
 ]
 
@@ -119,6 +153,17 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -284,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +361,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -323,10 +386,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indicatif"
@@ -346,6 +470,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
@@ -374,6 +504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +533,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +553,21 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -432,6 +595,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +651,12 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
@@ -498,6 +707,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +753,21 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -547,6 +800,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +834,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -602,10 +887,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -653,6 +981,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +1039,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -773,6 +1144,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,3 +1240,9 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,9 @@ xattr = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.27", features = ["ioctl"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+tempfile = "3"
+predicates = "3"
+walkdir = "2"

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -52,7 +52,8 @@ pub fn full_hash(path: &Path) -> Result<Hash> {
 fn read_at(file: &mut File, offset: u64, buffer: &mut [u8]) -> Result<()> {
     file.seek(SeekFrom::Start(offset))
         .with_context(|| "seek file")?;
-    file.read_exact(buffer).with_context(|| "read sparse chunk")?;
+    file.read_exact(buffer)
+        .with_context(|| "read sparse chunk")?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,12 @@ fn run() -> Result<()> {
             let groups = scan_pipeline(&path, &state)?;
             print_summary("scan", &groups);
         }
-        Commands::Dedupe { path, paranoid, dry_run, allow_unsafe_hardlinks } => {
+        Commands::Dedupe {
+            path,
+            paranoid,
+            dry_run,
+            allow_unsafe_hardlinks,
+        } => {
             let groups = scan_pipeline(&path, &state)?;
             dedupe_groups(&groups, &state, paranoid, dry_run, allow_unsafe_hardlinks)?;
             print_summary("dedupe", &groups);
@@ -94,9 +99,8 @@ fn scan_pipeline(path: &Path, state: &state::State) -> Result<HashMap<Hash, Vec<
 
     let (scan_tx, scan_rx) = channel::unbounded();
     let path_clone = path.to_path_buf();
-    let scanner_handle = std::thread::spawn(move || -> Result<()> {
-        scanner::stream_scan(&path_clone, scan_tx)
-    });
+    let scanner_handle =
+        std::thread::spawn(move || -> Result<()> { scanner::stream_scan(&path_clone, scan_tx) });
 
     let (hash_task_tx, hash_task_rx) = channel::unbounded::<PathBuf>();
 
@@ -213,35 +217,55 @@ fn dedupe_groups(
     let mut warn_reflink_unsupported = |name: &str| {
         if !reflink_warning_shown {
             println!("\n{}", "━".repeat(80).yellow());
-            println!("{} Filesystem Does Not Support Copy-on-Write Reflinks", "[WARNING]".bold().yellow());
+            println!(
+                "{} Filesystem Does Not Support Copy-on-Write Reflinks",
+                "[WARNING]".bold().yellow()
+            );
             println!("{}", "━".repeat(80).yellow());
             println!("\nYour filesystem does not support CoW (Copy-on-Write) reflinks.");
-            println!("Reflinks allow files to share disk space while remaining independent copies.");
-            println!("When you modify a reflinked file, only the changed portions use new disk space.\n");
+            println!(
+                "Reflinks allow files to share disk space while remaining independent copies."
+            );
+            println!(
+                "When you modify a reflinked file, only the changed portions use new disk space.\n"
+            );
             println!("{}", "Key differences:".bold());
-            println!("  • Reflinks: Different inodes, individual metadata, copy-on-write protection");
+            println!(
+                "  • Reflinks: Different inodes, individual metadata, copy-on-write protection"
+            );
             println!("  • Hard links: Shared inode, shared metadata, direct data sharing\n");
             println!("{}", "Implications:".bold());
-            println!("  • With hard links, modifying any file affects all linked copies and the vault master");
+            println!(
+                "  • With hard links, modifying any file affects all linked copies and the vault master"
+            );
             println!("  • All hard-linked files share the same timestamps and permissions");
             println!("  • Hard links save disk space but require careful file handling\n");
             println!("{}", "Your options:".bold());
-            println!("  1. {} - Files will be skipped (safe default)", "Do nothing".green());
-            println!("  2. {} - Enables deduplication with shared metadata", "Add --allow-unsafe-hardlinks".yellow());
-            println!("  3. {} - Btrfs, XFS (Linux), APFS (macOS), ReFS (Windows)\n", "Switch to a reflink-capable filesystem".cyan());
+            println!(
+                "  1. {} - Files will be skipped (safe default)",
+                "Do nothing".green()
+            );
+            println!(
+                "  2. {} - Enables deduplication with shared metadata",
+                "Add --allow-unsafe-hardlinks".yellow()
+            );
+            println!(
+                "  3. {} - Btrfs, XFS (Linux), APFS (macOS), ReFS (Windows)\n",
+                "Switch to a reflink-capable filesystem".cyan()
+            );
             println!("{}", "━".repeat(80).yellow());
             println!();
             reflink_warning_shown = true;
         }
         println!("{} {}", "[SKIPPED]".bold().red(), name);
     };
-    
+
     for (hash, paths) in groups {
         if paths.len() < 2 {
             continue;
         }
         let master = &paths[0];
-        
+
         let vault_path = if dry_run {
             let theoretical_path = vault::shard_path(hash)?;
             let name = display_name(master);
@@ -255,16 +279,13 @@ fn dedupe_groups(
         } else {
             vault::ensure_in_vault(hash, master)?
         };
-        
+
         let mut master_verified = false;
         if paranoid && !dry_run && master.exists() {
             match dedupe::compare_files(&vault_path, master) {
                 Ok(true) => master_verified = true,
                 Ok(false) => {
-                    eprintln!(
-                        "HASH COLLISION OR BIT ROT DETECTED: {}",
-                        master.display()
-                    );
+                    eprintln!("HASH COLLISION OR BIT ROT DETECTED: {}", master.display());
                     continue;
                 }
                 Err(err) => {
@@ -273,14 +294,14 @@ fn dedupe_groups(
                 }
             }
         }
-        
+
         if paranoid && dry_run {
             println!(
                 "{} Skipping paranoid verification (master not in vault)",
                 "[DRY RUN]".yellow().dimmed()
             );
         }
-        
+
         if !dry_run {
             match dedupe::replace_with_link(&vault_path, master, allow_unsafe_hardlinks) {
                 Ok(Some(link_type)) => {
@@ -356,10 +377,7 @@ fn dedupe_groups(
                 match dedupe::compare_files(&vault_path, path) {
                     Ok(true) => verified = true,
                     Ok(false) => {
-                        eprintln!(
-                            "HASH COLLISION OR BIT ROT DETECTED: {}",
-                            path.display()
-                        );
+                        eprintln!("HASH COLLISION OR BIT ROT DETECTED: {}", path.display());
                         continue;
                     }
                     Err(err) => {
@@ -368,7 +386,7 @@ fn dedupe_groups(
                     }
                 }
             }
-            
+
             if !dry_run {
                 match dedupe::replace_with_link(&vault_path, path, allow_unsafe_hardlinks) {
                     Ok(Some(link_type)) => {
@@ -427,7 +445,7 @@ fn dedupe_groups(
                 );
             }
         }
-        
+
         if !dry_run {
             state.set_cas_refcount(hash, paths.len() as u64)?;
         } else {
@@ -514,7 +532,7 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
 
         let inode = metadata.ino();
         let size = metadata.len();
-        
+
         let mut needs_restore = false;
         let mut target_hash: Option<Hash> = None;
 
@@ -523,8 +541,7 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
             if let Ok(Some(file_meta)) = state.get_file_metadata(&file_path) {
                 target_hash = Some(file_meta.hash);
             }
-        } 
-        else if let Ok(Some(file_meta)) = state.get_file_metadata(&file_path) {
+        } else if let Ok(Some(file_meta)) = state.get_file_metadata(&file_path) {
             if let Ok(vault_path) = vault::shard_path(&file_meta.hash) {
                 if vault_path.exists() {
                     needs_restore = true;
@@ -536,18 +553,22 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
         if needs_restore {
             let name = display_name(&file_path);
             restore_spinner.set_message(format!("Restoring {name}..."));
-            
+
             if dry_run {
                 println!("{} Would restore: {}", "[DRY RUN]".yellow().dimmed(), name);
                 if let Some(hash) = target_hash {
-                    println!("{}   -> Would decrement refcount for {}", "[DRY RUN]".yellow().dimmed(), crate::types::hash_to_hex(&hash));
+                    println!(
+                        "{}   -> Would decrement refcount for {}",
+                        "[DRY RUN]".yellow().dimmed(),
+                        crate::types::hash_to_hex(&hash)
+                    );
                 }
                 restored_count += 1;
                 bytes_restored += size;
             } else {
                 if dedupe::restore_file(&file_path).is_ok() {
                     println!("{} {}", "[RESTORED]".bold().cyan(), name);
-                    
+
                     let _ = state.unmark_inode_vaulted(inode);
                     let _ = state.remove_file_from_index(&file_path);
 
@@ -558,7 +579,10 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
                                 if current_refcount == 0 {
                                     let _ = vault::remove_from_vault(&hash);
                                     let _ = state.remove_cas_refcount(&hash);
-                                    println!("{}    -> Vault copy pruned (refcount 0)", "[GC]".bold().magenta());
+                                    println!(
+                                        "{}    -> Vault copy pruned (refcount 0)",
+                                        "[GC]".bold().magenta()
+                                    );
                                 } else {
                                     let _ = state.set_cas_refcount(&hash, current_refcount);
                                 }
@@ -577,8 +601,8 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
 
     restore_spinner.finish_and_clear();
     println!(
-        "Restore complete. Files restored: {} ({:.2} MB)", 
-        restored_count, 
+        "Restore complete. Files restored: {} ({:.2} MB)",
+        restored_count,
         bytes_restored as f64 / 1_048_576.0
     );
     Ok(())

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -1,4 +1,4 @@
-use crate::types::{hash_to_hex, Hash};
+use crate::types::{Hash, hash_to_hex};
 use anyhow::{Context, Result};
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -87,10 +87,16 @@ pub fn remove_from_vault(hash: &Hash) -> Result<()> {
         std::fs::remove_file(&dest).with_context(|| "remove file from vault")?;
 
         if let Some(shard_b) = dest.parent() {
-            if std::fs::read_dir(shard_b).map(|mut i| i.next().is_none()).unwrap_or(false) {
+            if std::fs::read_dir(shard_b)
+                .map(|mut i| i.next().is_none())
+                .unwrap_or(false)
+            {
                 let _ = std::fs::remove_dir(shard_b);
                 if let Some(shard_a) = shard_b.parent() {
-                    if std::fs::read_dir(shard_a).map(|mut i| i.next().is_none()).unwrap_or(false) {
+                    if std::fs::read_dir(shard_a)
+                        .map(|mut i| i.next().is_none())
+                        .unwrap_or(false)
+                    {
                         let _ = std::fs::remove_dir(shard_a);
                     }
                 }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -86,20 +86,18 @@ pub fn remove_from_vault(hash: &Hash) -> Result<()> {
     if dest.exists() {
         std::fs::remove_file(&dest).with_context(|| "remove file from vault")?;
 
-        if let Some(shard_b) = dest.parent() {
-            if std::fs::read_dir(shard_b)
+        if let Some(shard_b) = dest.parent()
+            && std::fs::read_dir(shard_b)
                 .map(|mut i| i.next().is_none())
                 .unwrap_or(false)
+        {
+            let _ = std::fs::remove_dir(shard_b);
+            if let Some(shard_a) = shard_b.parent()
+                && std::fs::read_dir(shard_a)
+                    .map(|mut i| i.next().is_none())
+                    .unwrap_or(false)
             {
-                let _ = std::fs::remove_dir(shard_b);
-                if let Some(shard_a) = shard_b.parent() {
-                    if std::fs::read_dir(shard_a)
-                        .map(|mut i| i.next().is_none())
-                        .unwrap_or(false)
-                    {
-                        let _ = std::fs::remove_dir(shard_a);
-                    }
-                }
+                let _ = std::fs::remove_dir(shard_a);
             }
         }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,346 @@
+use assert_cmd::Command;
+use std::fs;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+
+fn setup_env() -> tempfile::TempDir {
+    tempfile::TempDir::new().expect("Failed to create temp directory")
+}
+
+fn create_random_file(dir: &Path, name: &str, size: usize) -> PathBuf {
+    let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("Failed to create parent directories");
+    }
+    let content = vec![42u8; size];
+    fs::write(&path, content).expect("Failed to create random file");
+    path
+}
+
+fn create_file_with_content(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
+    let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("Failed to create parent directories");
+    }
+    fs::write(&path, content).expect("Failed to create file");
+    path
+}
+
+fn run_cmd(home_dir: &Path, args: &[&str]) -> assert_cmd::Command {
+    let mut cmd = Command::new(
+        std::env::current_exe()
+            .ok()
+            .and_then(|mut exe| {
+                exe.pop();
+                if exe.ends_with("deps") {
+                    exe.pop();
+                }
+                exe.push("bdstorage");
+                Some(exe)
+            })
+            .expect("Failed to find bdstorage binary"),
+    );
+    cmd.env("HOME", home_dir);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd
+}
+
+#[test]
+fn test_happy_path_dedupe_and_restore() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    for i in 0..5 {
+        create_random_file(&target, &format!("unique_{}.txt", i), 1024);
+    }
+
+    for i in 0..5 {
+        create_file_with_content(&target, &format!("dup_{}.txt", i), b"identical content");
+    }
+
+    let mut dedupe_cmd = run_cmd(home, &["dedupe", &target.to_string_lossy()]);
+    dedupe_cmd.assert().success();
+
+    let vault = home.join(".imprint").join("store");
+    assert!(vault.exists(), "Vault directory should exist after dedupe");
+
+    let file_count = fs::read_dir(&target)
+        .expect("Failed to read target directory")
+        .count();
+    assert_eq!(
+        file_count, 10,
+        "All 10 files should still exist after dedupe"
+    );
+
+    let mut restore_cmd = run_cmd(home, &["restore", &target.to_string_lossy()]);
+    restore_cmd.assert().success();
+
+    let vault_files: Vec<_> = walkdir::WalkDir::new(&vault)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .collect();
+
+    assert!(
+        vault_files.is_empty(),
+        "Vault should be empty after restore and GC"
+    );
+}
+
+#[test]
+fn test_zero_byte_files() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    for i in 0..5 {
+        create_file_with_content(&target, &format!("empty_{}.txt", i), b"");
+    }
+
+    let mut dedupe_cmd = run_cmd(home, &["dedupe", &target.to_string_lossy()]);
+    dedupe_cmd.assert().success();
+
+    let file_count = fs::read_dir(&target)
+        .expect("Failed to read target directory")
+        .count();
+    assert_eq!(file_count, 5, "All 5 empty files should still exist");
+}
+
+#[test]
+fn test_deeply_nested_directories() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let mut current = home.join("data");
+
+    for i in 0..20 {
+        current = current.join(format!("level_{}", i));
+    }
+
+    fs::create_dir_all(&current).expect("Failed to create nested directories");
+
+    for i in 0..3 {
+        create_file_with_content(&current, &format!("dup_{}.txt", i), b"nested content");
+    }
+
+    let root = home.join("data");
+    let mut dedupe_cmd = run_cmd(home, &["dedupe", &root.to_string_lossy()]);
+    dedupe_cmd.assert().success();
+
+    assert!(
+        current.join("dup_0.txt").exists(),
+        "Deeply nested files should exist"
+    );
+}
+
+#[test]
+fn test_massive_and_sparse_files() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    let file1_content = vec![0xAAu8; 15 * 1024];
+    let mut file2_content = vec![0xAAu8; 15 * 1024];
+
+    file2_content[7 * 1024] = 0xBB;
+
+    create_file_with_content(&target, "large1.bin", &file1_content);
+    create_file_with_content(&target, "large2.bin", &file2_content);
+
+    let mut dedupe_cmd = run_cmd(home, &["dedupe", &target.to_string_lossy()]);
+    dedupe_cmd.assert().success();
+
+    let vault = home.join(".imprint").join("store");
+    if vault.exists() {
+        let vault_files: Vec<_> = walkdir::WalkDir::new(&vault)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+            .collect();
+
+        assert!(
+            vault_files.len() >= 1,
+            "Vault should contain master files after dedupe of large files"
+        );
+    }
+}
+
+#[test]
+fn test_metadata_integrity() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    let _master_path = create_file_with_content(&target, "master.txt", b"test content");
+    let dup_path = create_file_with_content(&target, "duplicate.txt", b"test content");
+
+    fs::set_permissions(&dup_path, fs::Permissions::from_mode(0o444))
+        .expect("Failed to set permissions");
+
+    let test_time = filetime::FileTime::from_unix_time(1000000000, 0);
+    filetime::set_file_mtime(&dup_path, test_time).expect("Failed to set mtime");
+
+    let _ = xattr::set(&dup_path, "user.test_attr", b"test_value");
+
+    let mut dedupe_cmd = run_cmd(home, &["dedupe", &target.to_string_lossy()]);
+    dedupe_cmd.assert().success();
+
+    let dup_meta = fs::metadata(&dup_path).expect("Failed to read duplicate metadata");
+    let dup_mtime = filetime::FileTime::from_last_modification_time(&dup_meta);
+
+    assert_eq!(
+        dup_mtime, test_time,
+        "Modification time should be preserved"
+    );
+
+    let dup_perms = dup_meta.permissions();
+    let dup_mode = dup_perms.mode() & 0o777;
+    assert_eq!(
+        dup_mode, 0o444,
+        "Permissions should be preserved as read-only (0o444)"
+    );
+
+    if let Ok(Some(attr_val)) = xattr::get(&dup_path, "user.test_attr") {
+        assert_eq!(attr_val, b"test_value", "Extended attribute value should match");
+    }
+}
+
+#[test]
+fn test_hardlink_fallback() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    create_file_with_content(&target, "file1.txt", b"hardlink test");
+    create_file_with_content(&target, "file2.txt", b"hardlink test");
+
+    let mut dedupe_cmd = run_cmd(
+        home,
+        &[
+            "dedupe",
+            &target.to_string_lossy(),
+            "--allow-unsafe-hardlinks",
+        ],
+    );
+    dedupe_cmd.assert().success();
+
+    let file1_meta =
+        fs::metadata(&target.join("file1.txt")).expect("Failed to read file1 metadata");
+    let file2_meta =
+        fs::metadata(&target.join("file2.txt")).expect("Failed to read file2 metadata");
+
+    assert_eq!(
+        file1_meta.ino(),
+        file2_meta.ino(),
+        "Hardlinked files should have the same inode"
+    );
+}
+
+#[test]
+fn test_paranoid_mode_catches_bit_rot() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    create_file_with_content(&target, "file1.txt", b"content");
+    create_file_with_content(&target, "file2.txt", b"content");
+
+    let mut dedupe_cmd1 = run_cmd(home, &["dedupe", &target.to_string_lossy()]);
+    dedupe_cmd1.assert().success();
+
+    let vault = home.join(".imprint").join("store");
+    let vault_file = walkdir::WalkDir::new(&vault)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .next();
+
+    if let Some(vault_entry) = vault_file {
+        let vault_path = vault_entry.path().to_path_buf();
+        let mut file_content = fs::read(&vault_path).expect("Failed to read vault file");
+        file_content.push(0xFF);
+        fs::write(&vault_path, file_content).expect("Failed to corrupt vault file");
+
+        let mut dedupe_cmd2 = run_cmd(home, &["dedupe", &target.to_string_lossy(), "--paranoid"]);
+
+        let output = dedupe_cmd2.output().expect("Failed to run paranoid dedupe");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let combined = format!("{}{}", stdout, stderr);
+
+        assert!(
+            combined.contains("HASH COLLISION OR BIT ROT DETECTED")
+                || combined.contains("bit rot")
+                || combined.contains("collision")
+                || !output.status.success(),
+            "Paranoid mode should fail on bit rot or detect collision. Got: {}",
+            combined
+        );
+    }
+}
+
+#[test]
+fn test_scan_no_modifications() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    create_file_with_content(&target, "file1.txt", b"test");
+    create_file_with_content(&target, "file2.txt", b"test");
+
+    let metadata_before = fs::metadata(&target.join("file1.txt")).expect("Failed to read metadata");
+
+    let mut scan_cmd = run_cmd(home, &["scan", &target.to_string_lossy()]);
+    scan_cmd.assert().success();
+
+    let metadata_after =
+        fs::metadata(&target.join("file1.txt")).expect("Failed to read metadata after scan");
+
+    assert_eq!(
+        metadata_before.modified().unwrap(),
+        metadata_after.modified().unwrap(),
+        "Scan should not modify files"
+    );
+}
+
+#[test]
+fn test_dry_run_no_changes() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    create_file_with_content(&target, "file1.txt", b"test");
+    create_file_with_content(&target, "file2.txt", b"test");
+
+    let inode_before = fs::metadata(&target.join("file1.txt"))
+        .expect("Failed to read inode")
+        .ino();
+
+    let mut cmd = run_cmd(home, &["dedupe", &target.to_string_lossy(), "--dry-run"]);
+    cmd.assert().success();
+
+    let inode_after = fs::metadata(&target.join("file1.txt"))
+        .expect("Failed to read inode after dry-run")
+        .ino();
+
+    assert_eq!(
+        inode_before, inode_after,
+        "Dry-run should not modify file inodes"
+    );
+
+    let vault = home.join(".imprint").join("store");
+    assert!(
+        !vault.exists(),
+        "Vault should not be created in dry-run mode"
+    );
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -207,7 +207,10 @@ fn test_metadata_integrity() {
     );
 
     if let Ok(Some(attr_val)) = xattr::get(&dup_path, "user.test_attr") {
-        assert_eq!(attr_val, b"test_value", "Extended attribute value should match");
+        assert_eq!(
+            attr_val, b"test_value",
+            "Extended attribute value should match"
+        );
     }
 }
 


### PR DESCRIPTION
test(#28): implement robust integration test suite and CI pipeline

- Add integration test harness using `assert_cmd` and `tempfile` for safe `$HOME` sandboxing.
- Implement comprehensive test cases: happy path, zero-byte files, deep nesting, and tiered sparse-hashing collisions.
- Verify metadata integrity (mtime, permissions, xattrs) across the deduplication pipeline.
- Add safety checks for `--allow-unsafe-hardlinks` and `--paranoid` bit-rot detection.
- Add GitHub Actions workflow (`ci.yml`) to enforce formatting, linting, and sequential testing on `ubuntu-latest`.

Closes #28