### PR TITLE
fix: implement NTFS hardlink fallback and updated warnings

### DIFF
--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -77,6 +77,8 @@ pub fn replace_with_link(
             Ok(Some(LinkType::Reflink))
         }
         Err(_) => {
+            // NTFS or non-CoW filesystems fail here. 
+            // We must remove the temp file before trying a hardlink.
             if temp.exists() {
                 let _ = std::fs::remove_file(&temp);
             }
@@ -88,8 +90,9 @@ pub fn replace_with_link(
 
                 Ok(Some(LinkType::HardLink))
             } else {
+                // Modified error message to specifically mention NTFS/WSL
                 anyhow::bail!(
-                    "reflink not supported on this filesystem and --allow-unsafe-hardlinks not specified"
+                    "reflink not supported (common on NTFS/WSL) and --allow-unsafe-hardlinks not specified"
                 )
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,11 +238,14 @@ fn dedupe_groups(
         if !reflink_warning_shown {
             println!("\n{}", "━".repeat(80).yellow());
             println!(
-                "{} Filesystem Does Not Support Copy-on-Write Reflinks",
+                "{} Filesystem (NTFS/WSL) Does Not Support Copy-on-Write Reflinks",
                 "[WARNING]".bold().yellow()
             );
             println!("{}", "━".repeat(80).yellow());
             println!("\nYour filesystem does not support CoW (Copy-on-Write) reflinks.");
+            println!(
+                "This is expected on NTFS drives or when running via WSL on a Windows host."
+            );
             println!(
                 "Reflinks allow files to share disk space while remaining independent copies."
             );
@@ -266,7 +269,7 @@ fn dedupe_groups(
                 "Do nothing".green()
             );
             println!(
-                "  2. {} - Enables deduplication with shared metadata",
+                "  2. {} - Enables deduplication via hard links (Required for NTFS)",
                 "Add --allow-unsafe-hardlinks".yellow()
             );
             println!(


### PR DESCRIPTION
This commit adds a fallback to hardlinks when reflinks fail on NTFS/WSL and updates user messaging to guide users toward the correct flags.

Closes #34