### PR TITLE
feat(hasher): add mmap path for Tier 3 hashing on large files (#7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,12 +116,14 @@ dependencies = [
  "blake3",
  "clap",
  "colored",
+ "criterion",
  "crossbeam",
  "ctrlc",
  "filetime",
  "indicatif",
  "jwalk",
  "libc",
+ "memmap2",
  "nix 0.27.1",
  "predicates",
  "rayon",
@@ -184,6 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +218,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -290,6 +331,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +421,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctrlc"
@@ -454,6 +537,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +567,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "id-arena"
@@ -506,10 +606,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -585,6 +705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +783,40 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -942,6 +1105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1252,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1306,6 +1489,26 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 anyhow = "1"
 blake3 = "1"
 bincode = "1"
+memmap2 = "0.9"
 clap = { version = "4", features = ["derive"] }
 colored = "2"
 ctrlc = "3"
@@ -37,8 +38,13 @@ xattr = "1"
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.27", features = ["ioctl"] }
 
+[[bench]]
+name = "hash_bench"
+harness = false
+
 [dev-dependencies]
 assert_cmd = "2"
+criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3"
 predicates = "3"
 walkdir = "2"

--- a/benches/hash_bench.rs
+++ b/benches/hash_bench.rs
@@ -1,0 +1,43 @@
+use bdstorage::hasher::{full_hash, full_hash_buffered};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn make_temp_file(size: usize) -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("create temp file");
+    // Pseudorandom-looking pattern so the OS cannot trivially short-circuit reads.
+    let chunk: Vec<u8> = (0..256).map(|i| i as u8).cycle().take(size).collect();
+    f.write_all(&chunk).expect("write bench data");
+    f.flush().expect("flush bench data");
+    f
+}
+
+fn bench_full_hash(c: &mut Criterion) {
+    // Sizes chosen to cover: below threshold (buffered only), at threshold, well above.
+    let sizes: &[(usize, &str)] = &[
+        (512 * 1024, "512 KiB"),
+        (1024 * 1024, "1 MiB"),
+        (4 * 1024 * 1024, "4 MiB"),
+        (16 * 1024 * 1024, "16 MiB"),
+    ];
+
+    let mut group = c.benchmark_group("full_hash");
+
+    for &(size, label) in sizes {
+        let f = make_temp_file(size);
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("mmap", label), &f, |b, f| {
+            b.iter(|| full_hash(f.path()).expect("full_hash"));
+        });
+
+        group.bench_with_input(BenchmarkId::new("buffered", label), &f, |b, f| {
+            b.iter(|| full_hash_buffered(f.path()).expect("full_hash_buffered"));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_full_hash);
+criterion_main!(benches);

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 const SPARSE_CHUNK: usize = 4 * 1024;
 const SPARSE_TOTAL: u64 = 12 * 1024;
 const FULL_BUF: usize = 128 * 1024;
+const MMAP_THRESHOLD: u64 = 1024 * 1024;
 
 pub fn sparse_hash(path: &Path, size: u64) -> Result<Hash> {
     if size <= SPARSE_TOTAL {
@@ -35,9 +36,29 @@ pub fn sparse_hash(path: &Path, size: u64) -> Result<Hash> {
 
 pub fn full_hash(path: &Path) -> Result<Hash> {
     let mut file = File::open(path).with_context(|| format!("open file {:?}", path))?;
+    let len = file
+        .metadata()
+        .with_context(|| format!("read metadata {:?}", path))?
+        .len();
+
+    if len == 0 {
+        return Ok(blake3::hash(b"").into());
+    }
+
+    #[cfg(unix)]
+    if len >= MMAP_THRESHOLD {
+        // SAFETY: The file may be modified by another process while it is mapped.
+        // bdstorage operates on user-owned files not expected to be concurrently
+        // written. In the worst case a concurrent write produces a stale hash that
+        // the next scan will correct. The mapped region is used as a read-only
+        // &[u8] slice by BLAKE3, so no Rust memory-safety invariant is violated.
+        let mmap = unsafe { memmap2::Mmap::map(&file) }
+            .with_context(|| format!("mmap file {:?}", path))?;
+        return Ok(blake3::hash(&mmap[..]).into());
+    }
+
     let mut hasher = blake3::Hasher::new();
     let mut buffer = vec![0u8; FULL_BUF];
-
     loop {
         let read = file.read(&mut buffer).with_context(|| "read file")?;
         if read == 0 {
@@ -45,7 +66,22 @@ pub fn full_hash(path: &Path) -> Result<Hash> {
         }
         hasher.update(&buffer[..read]);
     }
+    Ok(hasher.finalize().into())
+}
 
+/// Always uses the 128 KB BufReader loop, regardless of file size.
+/// Exposed for benchmarking so the mmap and buffered paths can be compared directly.
+pub(crate) fn full_hash_buffered(path: &Path) -> Result<Hash> {
+    let mut file = File::open(path).with_context(|| format!("open file {:?}", path))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = vec![0u8; FULL_BUF];
+    loop {
+        let read = file.read(&mut buffer).with_context(|| "read file")?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
     Ok(hasher.finalize().into())
 }
 
@@ -115,4 +151,45 @@ fn adjust_offset_for_sparse(file: &File, target: u64, _file_size: u64) -> u64 {
 #[cfg(not(target_os = "linux"))]
 fn adjust_offset_for_sparse(_file: &File, target: u64, _file_size: u64) -> u64 {
     target
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn empty_file_produces_blake3_empty_hash() {
+        let f = NamedTempFile::new().unwrap();
+        let got = full_hash(f.path()).unwrap();
+        let want: Hash = blake3::hash(b"").into();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn buffered_and_mmap_paths_agree() {
+        // File size is above MMAP_THRESHOLD so the mmap branch is exercised on Unix.
+        // On non-Unix the buffered path runs for both; the assertion still holds.
+        let data = vec![0x5Au8; (MMAP_THRESHOLD + 4096) as usize];
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(&data).unwrap();
+        f.flush().unwrap();
+
+        let got = full_hash(f.path()).unwrap();
+        let want: Hash = blake3::hash(&data).into();
+        assert_eq!(got, want, "mmap and reference hash must match");
+    }
+
+    #[test]
+    fn small_file_below_mmap_threshold_is_correct() {
+        let data = b"hello bdstorage";
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(data).unwrap();
+        f.flush().unwrap();
+
+        let got = full_hash(f.path()).unwrap();
+        let want: Hash = blake3::hash(data).into();
+        assert_eq!(got, want);
+    }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -4,11 +4,14 @@ use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
+#[allow(dead_code)]
 const SPARSE_CHUNK: usize = 4 * 1024;
+#[allow(dead_code)]
 const SPARSE_TOTAL: u64 = 12 * 1024;
 const FULL_BUF: usize = 128 * 1024;
 const MMAP_THRESHOLD: u64 = 1024 * 1024;
 
+#[allow(dead_code)]
 pub fn sparse_hash(path: &Path, size: u64) -> Result<Hash> {
     if size <= SPARSE_TOTAL {
         return full_hash(path);
@@ -47,14 +50,15 @@ pub fn full_hash(path: &Path) -> Result<Hash> {
 
     #[cfg(unix)]
     if len >= MMAP_THRESHOLD {
-        // SAFETY: The file may be modified by another process while it is mapped.
-        // bdstorage operates on user-owned files not expected to be concurrently
-        // written. In the worst case a concurrent write produces a stale hash that
-        // the next scan will correct. The mapped region is used as a read-only
-        // &[u8] slice by BLAKE3, so no Rust memory-safety invariant is violated.
-        let mmap = unsafe { memmap2::Mmap::map(&file) }
-            .with_context(|| format!("mmap file {:?}", path))?;
-        return Ok(blake3::hash(&mmap[..]).into());
+        // SAFETY: The mapped region is passed as a read-only &[u8] to BLAKE3; no
+        // Rust memory-safety invariant is violated. A concurrent external truncation
+        // could theoretically cause SIGBUS when accessing the now-invalid pages, but
+        // bdstorage operates on user-owned files not expected to be modified during
+        // a scan. If mapping fails for any reason (e.g. ENOMEM, unsupported fs) we
+        // fall through to the chunked-read path so no file is silently dropped.
+        if let Ok(mmap) = unsafe { memmap2::Mmap::map(&file) } {
+            return Ok(blake3::hash(&mmap[..]).into());
+        }
     }
 
     let mut hasher = blake3::Hasher::new();
@@ -69,9 +73,9 @@ pub fn full_hash(path: &Path) -> Result<Hash> {
     Ok(hasher.finalize().into())
 }
 
-/// Always uses the 128 KB BufReader loop, regardless of file size.
-/// Exposed for benchmarking so the mmap and buffered paths can be compared directly.
-pub(crate) fn full_hash_buffered(path: &Path) -> Result<Hash> {
+/// Always uses the 128 KB chunked read loop, regardless of file size.
+/// Exposed for benchmarking so the mmap and chunked-read paths can be compared directly.
+pub fn full_hash_buffered(path: &Path) -> Result<Hash> {
     let mut file = File::open(path).with_context(|| format!("open file {:?}", path))?;
     let mut hasher = blake3::Hasher::new();
     let mut buffer = vec![0u8; FULL_BUF];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod hasher;
+pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,9 +247,7 @@ fn scan_pipeline(path: &Path, state: &state::State) -> Result<HashMap<Hash, Vec<
                     }
 
                     let size = metadata.len();
-                    if let Ok(_) = hasher::sparse_hash(&file_path, size)
-                        && let Ok(full_hash) = hasher::full_hash(&file_path)
-                    {
+                    if let Ok(full_hash) = hasher::full_hash(&file_path) {
                         let modified = file_modified(&file_path).unwrap_or(0);
                         let file_metadata = FileMetadata {
                             size,


### PR DESCRIPTION
For files >= 1 MiB on Unix, full_hash now memory-maps the file and passes the mapped slice directly to blake3::hash(), eliminating the 128 KB userspace copy loop. Smaller files and non-Unix targets keep the existing BufReader path unchanged.

Also removes the dead sparse_hash() call in the scan worker whose return value was discarded, causing every file to be read twice.

- Add memmap2 = 0.9 dependency
- Add src/lib.rs to expose hasher for Criterion benchmarks
- Add benches/hash_bench.rs: mmap vs buffered at 512 KiB/1 MiB/4 MiB/16 MiB
- Add three unit tests in hasher.rs covering empty file, mmap/buffered agreement, and small-file correctness

Closes #7