### PR TITLE
ci: add XFS reflink validation using loopback device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,35 @@ jobs:
       - name: Build release
         run: cargo build --release
 
+  xfs-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust caching
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install xfsprogs
+        run: sudo apt-get update && sudo apt-get install -y xfsprogs
+
+      - name: Create and mount XFS loopback device
+        run: |
+          truncate -s 512M xfs.img
+          sudo mkfs.xfs -m reflink=1 xfs.img
+          sudo mkdir /mnt/xfs
+          sudo mount -o loop xfs.img /mnt/xfs
+          sudo chmod 777 /mnt/xfs
+
+      - name: Run XFS integration tests
+        run: cargo test -- --test-threads=1
+        env:
+          BDSTORAGE_TEST_ROOT: /mnt/xfs
+          BDSTORAGE_TEST_XFS: 1
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,7 +5,15 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn setup_env() -> tempfile::TempDir {
-    tempfile::TempDir::new().expect("Failed to create temp directory")
+    if let Ok(root) = std::env::var("BDSTORAGE_TEST_ROOT") {
+        let root_path = PathBuf::from(root);
+        if !root_path.exists() {
+            fs::create_dir_all(&root_path).expect("Failed to create BDSTORAGE_TEST_ROOT");
+        }
+        tempfile::tempdir_in(root_path).expect("Failed to create temp directory in custom root")
+    } else {
+        tempfile::TempDir::new().expect("Failed to create temp directory")
+    }
 }
 
 fn create_random_file(dir: &Path, name: &str, size: usize) -> PathBuf {
@@ -375,5 +383,47 @@ fn test_dry_run_no_changes() {
     assert!(
         !imprint_dir.exists(),
         "Entire .imprint directory (vault and database) must not exist in dry-run mode"
+    );
+}
+
+#[test]
+fn test_xfs_reflink_validation() {
+    // This test is intended to be run on an XFS filesystem with reflink=1 (e.g., in CI)
+    if std::env::var("BDSTORAGE_TEST_XFS").is_err() {
+        return;
+    }
+
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    create_file_with_content(&target, "file1.txt", b"xfs reflink validation content");
+    create_file_with_content(&target, "file2.txt", b"xfs reflink validation content");
+
+    let mut dedupe_cmd = run_cmd(home, &["dedupe", &target.to_string_lossy()]);
+    let output = dedupe_cmd.output().expect("Failed to run dedupe");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "Dedupe failed on XFS: {}\nStdout: {}",
+        stderr,
+        stdout
+    );
+    assert!(
+        stdout.contains("[REFLINK ]"),
+        "Should have used REFLINK on XFS filesystem. Output:\n{}",
+        stdout
+    );
+
+    // Verify inodes are different
+    let meta1 = fs::metadata(target.join("file1.txt")).unwrap();
+    let meta2 = fs::metadata(target.join("file2.txt")).unwrap();
+    assert_ne!(
+        meta1.ino(),
+        meta2.ino(),
+        "Reflinked files should have different inodes"
     );
 }


### PR DESCRIPTION
Addresses #32.

## Summary
This PR introduces automated testing support for XFS filesystems with reflink functionality enabled.

## Key Changes

### Test Infrastructure
- Enhanced `tests/integration_tests.rs` to support custom sandbox roots via `BDSTORAGE_TEST_ROOT`.

### XFS Validation
- Added `test_xfs_reflink_validation` to explicitly verify:
  - Detection of XFS reflink capabilities.
  - Correct execution of block-level cloning operations.

### CI Automation
- Added an `xfs-test` job to `ci.yml` that:
  - Installs and provisions `xfsprogs`.
  - Creates and mounts an XFS loopback device with `reflink=1` enabled.
  - Validates the complete deduplication workflow, including:
    - Sparse hashing
    - `FIEMAP` ioctl handling
    - Reflink-based deduplication behavior

## Result
This ensures `bdstorage` remains fully compatible with modern enterprise Linux storage environments and validates reliable CoW-based deduplication behavior on XFS filesystems.