### PR TITLE
docs: add ZFS support and block-cloning limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ When identical files are confirmed, `bdstorage` uses a **Content-Addressable Sto
 * **Filesystem:** For maximum performance and safety, a filesystem that supports **reflinks** (e.g., Btrfs, XFS) is strongly recommended.
 * **Rust:** Latest stable toolchain (if building from source).
 
+### ZFS Support
+`bdstorage` supports **OpenZFS 2.2+** native block-cloning. 
+
+* **OpenZFS 2.2 and newer:** Supports native CoW reflinks. `bdstorage` will automatically use `LinkType::Reflink` for instant, space-efficient deduplication while preserving independent file metadata (timestamps, permissions).
+* **OpenZFS < 2.2:** Does not support explicit block-cloning. By default, `bdstorage` will skip these files and report that reflinks are not supported.
+* **Workaround for older ZFS:** If you are on an older version of ZFS and want to save space, use the `--allow-unsafe-hardlinks` flag. **Warning:** This uses hard links, meaning all duplicates will share the same inode and metadata. Modifying one copy will affect all others.
+
 ---
 
 ## Installation


### PR DESCRIPTION
@Rakshat28 
Addresses #33.

This PR adds comprehensive documentation regarding bdstorage compatibility with OpenZFS and verifies that the engine handles ZFS version-specific limitations gracefully.

Key Changes:
New Documentation Section: Added "ZFS Support" to the README.md to guide users on version requirements for native block-cloning.
Version Guidance:
OpenZFS 2.2+: Confirmed support for native CoW reflinks.
Legacy ZFS: Documented the requirement for --allow-unsafe-hardlinks for users who still wish to achieve deduplication on older pools.
Behavior Verification: Confirmed that the error-handling path in src/dedupe.rs provides the expected "graceful failure" when reflinks are unavailable, preventing accidental data loss or silent skips without user notification.
This update ensures that ZFS users can safely and effectively use bdstorage according to their specific environment.