### PR TITLE
ci: add NTFS hardlink fallback validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,35 @@ jobs:
       - name: Build release
         run: cargo build --release
 
+  ntfs-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust caching
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install ntfs-3g
+        run: sudo apt-get update && sudo apt-get install -y ntfs-3g
+
+      - name: Create and mount NTFS loopback device
+        run: |
+          truncate -s 512M ntfs.img
+          sudo mkfs.ntfs -F ntfs.img
+          sudo mkdir /mnt/ntfs
+          sudo mount -t ntfs-3g -o loop ntfs.img /mnt/ntfs
+          sudo chmod 777 /mnt/ntfs
+
+      - name: Run NTFS integration tests
+        run: cargo test -- --test-threads=1
+        env:
+          BDSTORAGE_TEST_ROOT: /mnt/ntfs
+          BDSTORAGE_TEST_NTFS: 1
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,7 +5,15 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn setup_env() -> tempfile::TempDir {
-    tempfile::TempDir::new().expect("Failed to create temp directory")
+    if let Ok(root) = std::env::var("BDSTORAGE_TEST_ROOT") {
+        let root_path = PathBuf::from(root);
+        if !root_path.exists() {
+            fs::create_dir_all(&root_path).expect("Failed to create BDSTORAGE_TEST_ROOT");
+        }
+        tempfile::tempdir_in(root_path).expect("Failed to create temp directory in custom root")
+    } else {
+        tempfile::TempDir::new().expect("Failed to create temp directory")
+    }
 }
 
 fn create_random_file(dir: &Path, name: &str, size: usize) -> PathBuf {
@@ -375,5 +383,64 @@ fn test_dry_run_no_changes() {
     assert!(
         !imprint_dir.exists(),
         "Entire .imprint directory (vault and database) must not exist in dry-run mode"
+    );
+}
+
+#[test]
+fn test_ntfs_hardlink_fallback() {
+    // This test is intended to be run on a filesystem that does NOT support reflinks (e.g., NTFS)
+    if std::env::var("BDSTORAGE_TEST_NTFS").is_err() {
+        return;
+    }
+
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    create_file_with_content(&target, "file1.txt", b"ntfs fallback content");
+    create_file_with_content(&target, "file2.txt", b"ntfs fallback content");
+
+    // First, try without --allow-unsafe-hardlinks. It should skip/warn.
+    let mut dedupe_cmd_fail = run_cmd(home, &["dedupe", &target.to_string_lossy()]);
+    let output_fail = dedupe_cmd_fail.output().expect("Failed to run dedupe");
+    let stdout_fail = String::from_utf8_lossy(&output_fail.stdout);
+
+    assert!(
+        stdout_fail.contains("SKIPPED") || stdout_fail.contains("WARNING") || stdout_fail.contains("not support"),
+        "Should have warned about missing reflink support. Output:\n{}",
+        stdout_fail
+    );
+
+    // Now, try with --allow-unsafe-hardlinks.
+    let mut dedupe_cmd_pass = run_cmd(
+        home,
+        &[
+            "dedupe",
+            &target.to_string_lossy(),
+            "--allow-unsafe-hardlinks",
+        ],
+    );
+    let output_pass = dedupe_cmd_pass.output().expect("Failed to run dedupe");
+    let stdout_pass = String::from_utf8_lossy(&output_pass.stdout);
+
+    assert!(
+        output_pass.status.success(),
+        "Dedupe failed with hardlinks allowed: {}",
+        String::from_utf8_lossy(&output_pass.stderr)
+    );
+    assert!(
+        stdout_pass.contains("[HARDLINK]"),
+        "Should have used HARDLINK fallback. Output:\n{}",
+        stdout_pass
+    );
+
+    // Verify inodes are the same
+    let meta1 = fs::metadata(target.join("file1.txt")).unwrap();
+    let meta2 = fs::metadata(target.join("file2.txt")).unwrap();
+    assert_eq!(
+        meta1.ino(),
+        meta2.ino(),
+        "Hardlinked files must share the same inode"
     );
 }


### PR DESCRIPTION
Addresses #34.

## Summary
This PR adds automated validation for NTFS storage environments, improving compatibility for WSL users and systems using external NTFS-formatted drives.

## Key Changes

### Hardlink Fallback Testing
- Added `test_ntfs_hardlink_fallback` to `tests/integration_tests.rs`.
- Validates that `bdstorage` correctly handles environments where reflinks are unavailable by:
  - Safely skipping unsupported operations, or
  - Falling back to hard links when explicitly enabled.

### Cross-Boundary Verification
- Verified that hard links are correctly created and detected across the NTFS mount within the Linux environment.

### NTFS CI Job
- Added a dedicated `ntfs-test` job to `ci.yml` that:
  - Provisions an NTFS loopback device.
  - Executes integration tests against the mounted NTFS filesystem.
  - Ensures fallback deduplication logic is continuously validated in CI, regardless of the host runner’s primary filesystem.

## Result
This update significantly improves the reliability and portability of `bdstorage` for users operating in mixed-OS setups, WSL environments, and legacy filesystem configurations.