### PR TITLE
feat: allow custom vault and database locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,17 @@ Check the **link count** column (the number after permissions):
 
 ## Data Locations & Storage
 
-Your data never leaves your machine. `bdstorage` uses **`$HOME/.imprint/`** (from the **`HOME`** environment variable):
+Your data never leaves your machine. By default, `bdstorage` uses **`$HOME/.imprint/`**:
 
 * **State DB:** `~/.imprint/state.redb`
 * **CAS Vault:** `~/.imprint/store/`
+
+### Configurable Vault Path
+You can override the default storage location using:
+* **Global Flag:** `bdstorage --vault-dir /path/to/custom/vault dedupe ...`
+* **Environment Variable:** `export BDSTORAGE_VAULT=/path/to/custom/vault`
+
+When a custom path is provided, the database will be stored as `state.redb` and the vault as `store/` directly inside that directory.
 
 To perform a completely clean reset of the engine:
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ use crate::types::{FileMetadata, Hash};
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+    #[arg(long, env = "BDSTORAGE_VAULT", global = true)]
+    vault_dir: Option<PathBuf>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -106,19 +108,19 @@ fn run() -> Result<()> {
 
     match args.command {
         Commands::Scan { path } => {
-            let state = state::State::open_default()?;
+            let state = state::State::open_default(args.vault_dir.clone())?;
             let groups = scan_pipeline(&path, &state)?;
             print_summary("scan", &groups);
         }
         Commands::Dedupe(opts) => {
-            let summary = run_dedupe_once(&opts)?;
+            let summary = run_dedupe_once(&opts, args.vault_dir.clone())?;
             println!(
                 "dedupe complete. duplicate groups: {} files linked: {}",
                 summary.duplicate_groups, summary.files_linked
             );
         }
         Commands::Daemon { command } => match command {
-            DaemonCommand::Run(opts) => run_daemon(opts.dedupe, opts.interval_secs)?,
+            DaemonCommand::Run(opts) => run_daemon(opts.dedupe, opts.interval_secs, args.vault_dir.clone())?,
             DaemonCommand::Install(opts) => systemd::install_daemon_service(
                 &opts.target,
                 opts.interval_secs,
@@ -127,22 +129,22 @@ fn run() -> Result<()> {
         },
         Commands::Restore { path, dry_run } => {
             let state = if dry_run {
-                state::State::open_readonly_if_exists()?
+                state::State::open_readonly_if_exists(args.vault_dir.clone())?
             } else {
-                state::State::open_default()?
+                state::State::open_default(args.vault_dir.clone())?
             };
-            restore_pipeline(&path, &state, dry_run)?;
+            restore_pipeline(&path, &state, dry_run, args.vault_dir.clone())?;
         }
     }
 
     Ok(())
 }
 
-fn run_dedupe_once(opts: &DedupeOptions) -> Result<DedupeRunSummary> {
+fn run_dedupe_once(opts: &DedupeOptions, vault_dir: Option<PathBuf>) -> Result<DedupeRunSummary> {
     let state = if opts.dry_run {
-        state::State::open_readonly_if_exists()?
+        state::State::open_readonly_if_exists(vault_dir.clone())?
     } else {
-        state::State::open_default()?
+        state::State::open_default(vault_dir.clone())?
     };
     let groups = scan_pipeline(&opts.path, &state)?;
     dedupe_groups(
@@ -151,10 +153,11 @@ fn run_dedupe_once(opts: &DedupeOptions) -> Result<DedupeRunSummary> {
         opts.paranoid,
         opts.dry_run,
         opts.allow_unsafe_hardlinks,
+        vault_dir,
     )
 }
 
-fn run_daemon(opts: DedupeOptions, interval_secs: u64) -> Result<()> {
+fn run_daemon(opts: DedupeOptions, interval_secs: u64, vault_dir: Option<PathBuf>) -> Result<()> {
     let (shutdown_tx, shutdown_rx) = channel::bounded::<()>(1);
     ctrlc::set_handler(move || {
         let _ = shutdown_tx.try_send(());
@@ -174,7 +177,7 @@ fn run_daemon(opts: DedupeOptions, interval_secs: u64) -> Result<()> {
 
         println!("[daemon] run #{run_no} started");
         let started = std::time::Instant::now();
-        match run_dedupe_once(&opts) {
+        match run_dedupe_once(&opts, vault_dir.clone()) {
             Ok(summary) => {
                 println!(
                     "[daemon] run #{run_no} complete in {:.2}s; duplicate_groups={} files_linked={}",
@@ -337,6 +340,7 @@ fn dedupe_groups(
     paranoid: bool,
     dry_run: bool,
     allow_unsafe_hardlinks: bool,
+    vault_dir: Option<PathBuf>,
 ) -> Result<DedupeRunSummary> {
     let mut global_db_ops = Vec::new();
     let mut files_linked = 0usize;
@@ -395,7 +399,7 @@ fn dedupe_groups(
         let master = &paths[0];
 
         let vault_path = if dry_run {
-            let theoretical_path = vault::shard_path(hash)?;
+            let theoretical_path = vault::shard_path(hash, vault_dir.clone())?;
             let name = display_name(master);
             println!(
                 "{} Would move master: {} -> {}",
@@ -405,7 +409,7 @@ fn dedupe_groups(
             );
             theoretical_path
         } else {
-            vault::ensure_in_vault(hash, master)?
+            vault::ensure_in_vault(hash, master, vault_dir.clone())?
         };
 
         let mut master_verified = false;
@@ -644,7 +648,7 @@ fn print_summary(mode: &str, groups: &HashMap<Hash, Vec<PathBuf>>) {
     println!("{mode} complete. duplicate groups: {duplicates}");
 }
 
-fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<()> {
+fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool, vault_dir: Option<PathBuf>) -> Result<()> {
     let multi = MultiProgress::new();
     let restore_spinner = multi.add(ProgressBar::new_spinner());
     restore_spinner.set_style(
@@ -688,7 +692,7 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
                 target_hash = Some(file_meta.hash);
             }
         } else if let Ok(Some(file_meta)) = state.get_file_metadata(&file_path)
-            && let Ok(vault_path) = vault::shard_path(&file_meta.hash)
+            && let Ok(vault_path) = vault::shard_path(&file_meta.hash, vault_dir.clone())
             && vault_path.exists()
         {
             needs_restore = true;
@@ -724,7 +728,7 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
                 {
                     current_refcount -= 1;
                     if current_refcount == 0 {
-                        let _ = vault::remove_from_vault(&hash);
+                        let _ = vault::remove_from_vault(&hash, vault_dir.clone());
                         restore_ops.push(DbOp::RemoveCasRefcount(hash));
                         println!(
                             "{}    -> Vault copy pruned (refcount 0)",

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,16 +26,19 @@ pub struct State {
 
 #[allow(dead_code)]
 impl State {
-    pub fn open_default() -> Result<Self> {
-        Self::open_default_impl(false)
+    pub fn open_default(custom_path: Option<PathBuf>) -> Result<Self> {
+        Self::open_default_impl(false, custom_path)
     }
 
-    pub fn open_readonly_if_exists() -> Result<Self> {
-        let db_path = default_db_path()?;
+    pub fn open_readonly_if_exists(custom_path: Option<PathBuf>) -> Result<Self> {
+        let db_path = match custom_path {
+            Some(ref p) => p.join("state.redb"),
+            None => default_db_path()?,
+        };
         if !db_path.exists() {
             return Self::create_dummy();
         }
-        Self::open_default_impl(true)
+        Self::open_default_impl(true, custom_path)
     }
 
     fn create_dummy() -> Result<Self> {
@@ -55,8 +58,11 @@ impl State {
         })
     }
 
-    fn open_default_impl(readonly: bool) -> Result<Self> {
-        let db_path = default_db_path()?;
+    fn open_default_impl(readonly: bool, custom_path: Option<PathBuf>) -> Result<Self> {
+        let db_path = match custom_path {
+            Some(p) => p.join("state.redb"),
+            None => default_db_path()?,
+        };
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("create state directory {:?}", parent))?;

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -29,21 +29,24 @@ impl Drop for TempCleanup {
     }
 }
 
-pub fn vault_root() -> Result<PathBuf> {
+pub fn vault_root(custom_path: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(p) = custom_path {
+        return Ok(p.join("store"));
+    }
     let home = std::env::var("HOME").with_context(|| "HOME not set")?;
     Ok(PathBuf::from(home).join(".imprint").join("store"))
 }
 
-pub fn shard_path(hash: &Hash) -> Result<PathBuf> {
+pub fn shard_path(hash: &Hash, custom_path: Option<PathBuf>) -> Result<PathBuf> {
     let hex = hash_to_hex(hash);
     let shard_a = &hex[0..2];
     let shard_b = &hex[2..4];
-    let root = vault_root()?;
+    let root = vault_root(custom_path)?;
     Ok(root.join(shard_a).join(shard_b).join(hex))
 }
 
-pub fn ensure_in_vault(hash: &Hash, src: &Path) -> Result<PathBuf> {
-    let dest = shard_path(hash)?;
+pub fn ensure_in_vault(hash: &Hash, src: &Path, custom_path: Option<PathBuf>) -> Result<PathBuf> {
+    let dest = shard_path(hash, custom_path.clone())?;
     if dest.exists() {
         return Ok(dest);
     }
@@ -81,8 +84,8 @@ pub fn ensure_in_vault(hash: &Hash, src: &Path) -> Result<PathBuf> {
     Ok(dest)
 }
 
-pub fn remove_from_vault(hash: &Hash) -> Result<()> {
-    let dest = shard_path(hash)?;
+pub fn remove_from_vault(hash: &Hash, custom_path: Option<PathBuf>) -> Result<()> {
+    let dest = shard_path(hash, custom_path)?;
     if dest.exists() {
         std::fs::remove_file(&dest).with_context(|| "remove file from vault")?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -377,3 +377,35 @@ fn test_dry_run_no_changes() {
         "Entire .imprint directory (vault and database) must not exist in dry-run mode"
     );
 }
+
+#[test]
+fn test_custom_vault_path() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    let custom_vault = home.join("custom_vault");
+    fs::create_dir(&target).expect("Failed to create target directory");
+    fs::create_dir(&custom_vault).expect("Failed to create custom vault directory");
+
+    create_file_with_content(&target, "file1.txt", b"custom vault content");
+    create_file_with_content(&target, "file2.txt", b"custom vault content");
+
+    let mut dedupe_cmd = run_cmd(home, &[
+        "--vault-dir", &custom_vault.to_string_lossy(),
+        "dedupe", &target.to_string_lossy()
+    ]);
+    dedupe_cmd.assert().success();
+
+    // Verify vault and DB exist in custom location
+    assert!(custom_vault.join("store").exists(), "Vault store should be in custom location");
+    assert!(custom_vault.join("state.redb").exists(), "State DB should be in custom location");
+
+    let mut restore_cmd = run_cmd(home, &[
+        "--vault-dir", &custom_vault.to_string_lossy(),
+        "restore", &target.to_string_lossy()
+    ]);
+    restore_cmd.assert().success();
+
+    let content = fs::read(target.join("file1.txt")).unwrap();
+    assert_eq!(content, b"custom vault content");
+}


### PR DESCRIPTION
@Rakshat28 
Addresses #45.

## Summary
This PR adds support for configurable storage locations for `bdstorage` internal data, enabling users to relocate the vault and state database outside the default home directory.

## Key Changes

### Flexible Storage Path
- Introduced a global `--vault-dir` flag.
- When specified, both:
  - the `state.redb` database, and
  - the `store/` vault directory  
  are created and managed within the provided path.

### Environment Integration
- Added support for the `BDSTORAGE_VAULT` environment variable.
- Allows persistent or script-based configuration without requiring the CLI flag for every invocation.

### Code Decoupling
- Refactored the state and vault modules to eliminate hardcoded dependencies on the user’s home directory.
- Improves portability, modularity, and support for custom deployment environments.

### Verified Support
- Added a dedicated integration test covering custom vault path scenarios.
- Ensures path resolution, initialization, and database interactions behave correctly across non-default storage locations.

## Result
This feature enables users to place large vaults on secondary or high-capacity drives while keeping the primary system disk clean and reducing storage pressure on constrained environments.