### PR TITLE
feat: configurable vault location via --vault-dir flag and BDSTORAGE_VAULT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ cargo build --release
    bdstorage dedupe /path/to/tree -n    # dry-run: no writes
    bdstorage dedupe /path/to/tree       # real run
    ```
-4. **State and vault** are created under **`$HOME/.imprint/`** on first use ([Data Locations & Storage](#-data-locations--storage)).
+4. **State and vault** are created under **`$HOME/.imprint/`** on first use (overridable via `--vault-dir` or `$BDSTORAGE_VAULT`; see [Data Locations & Storage](#-data-locations--storage)).
 
 Use **`bdstorage --help`** and **`bdstorage <subcommand> --help`** for the full CLI.
 
@@ -293,10 +293,21 @@ Check the **link count** column (the number after permissions):
 
 ## Data Locations & Storage
 
-Your data never leaves your machine. `bdstorage` uses **`$HOME/.imprint/`** (from the **`HOME`** environment variable):
+Your data never leaves your machine. By default, `bdstorage` uses **`$HOME/.imprint/`**:
 
 * **State DB:** `~/.imprint/state.redb`
 * **CAS Vault:** `~/.imprint/store/`
+
+### Overriding the vault location
+
+You can point the vault and state DB at a different directory in two ways (listed in priority order):
+
+| Method | Example |
+|:---|:---|
+| CLI flag | `bdstorage --vault-dir /mnt/bigdisk dedupe ~/Downloads` |
+| Environment variable | `export BDSTORAGE_VAULT=/mnt/bigdisk` |
+
+Both `state.redb` and `store/` will be placed inside the chosen directory.
 
 To perform a completely clean reset of the engine:
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,14 @@ use crate::types::{FileMetadata, Hash};
     version,
     about = "bdstorage: A speed-first, local file deduplication engine.",
     long_about = "bdstorage uses a Tiered Hashing philosophy to minimize I/O overhead:\n\nSize Grouping: Eliminates unique file sizes immediately.\n\nSparse Hashing: Samples 12KB (start/middle/end) to identify candidates.\n\nFull BLAKE3 Hashing: Verifies matches with high-performance 128KB buffering.",
-    help_template = "{before-help}{name} {version}\n{author-with-newline}{about-section}\n\nSTORAGE PATHS:\n  State DB: ~/.imprint/state.redb\n  CAS Vault: ~/.imprint/store\n\n{usage-heading} {usage}\n\nGLOBAL FLAGS:\n  -h, --help     Print help\n  -V, --version  Print version\n\nSUBCOMMAND FLAGS:\n  --paranoid                 Available on the dedupe subcommand. Forces a byte-for-byte\n                             verification before linking to guarantee 100% collision safety.\n\n  --allow-unsafe-hardlinks   Available on the dedupe subcommand. Allows hard link fallback\n                             when CoW reflinks are not supported. Hard links share the same\n                             inode, so all linked files will have identical metadata.\n\n  -n, --dry-run              Available on dedupe and restore subcommands. Simulates operations\n                             without modifying the filesystem or the database.\n\n{all-args}{after-help}"
+    help_template = "{before-help}{name} {version}\n{author-with-newline}{about-section}\n\nSTORAGE PATHS (override: --vault-dir or $BDSTORAGE_VAULT):\n  State DB: <vault-dir>/state.redb  (default: ~/.imprint/state.redb)\n  CAS Vault: <vault-dir>/store/     (default: ~/.imprint/store/)\n\n{usage-heading} {usage}\n\nGLOBAL FLAGS:\n  --vault-dir <PATH>   Override vault/state directory (env: BDSTORAGE_VAULT)\n  -h, --help           Print help\n  -V, --version        Print version\n\nSUBCOMMAND FLAGS:\n  --paranoid                 Available on the dedupe subcommand. Forces a byte-for-byte\n                             verification before linking to guarantee 100% collision safety.\n\n  --allow-unsafe-hardlinks   Available on the dedupe subcommand. Allows hard link fallback\n                             when CoW reflinks are not supported. Hard links share the same\n                             inode, so all linked files will have identical metadata.\n\n  -n, --dry-run              Available on dedupe and restore subcommands. Simulates operations\n                             without modifying the filesystem or the database.\n\n{all-args}{after-help}"
 )]
 struct Cli {
+    /// Override the vault and state directory.
+    /// Falls back to $BDSTORAGE_VAULT env var, then $HOME/.imprint/.
+    #[arg(long, global = true, env = "BDSTORAGE_VAULT")]
+    vault_dir: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -94,6 +99,16 @@ struct DedupeRunSummary {
     files_linked: usize,
 }
 
+fn resolve_vault_dir(cli_override: Option<&Path>) -> Result<PathBuf> {
+    match cli_override {
+        Some(p) => Ok(p.to_path_buf()),
+        None => {
+            let home = std::env::var("HOME").with_context(|| "HOME not set")?;
+            Ok(PathBuf::from(home).join(".imprint"))
+        }
+    }
+}
+
 fn main() {
     if let Err(err) = run() {
         eprintln!("{err:?}");
@@ -103,22 +118,23 @@ fn main() {
 
 fn run() -> Result<()> {
     let args = Cli::parse();
+    let vault_dir = resolve_vault_dir(args.vault_dir.as_deref())?;
 
     match args.command {
         Commands::Scan { path } => {
-            let state = state::State::open_default()?;
+            let state = state::State::open_default(&vault_dir)?;
             let groups = scan_pipeline(&path, &state)?;
             print_summary("scan", &groups);
         }
         Commands::Dedupe(opts) => {
-            let summary = run_dedupe_once(&opts)?;
+            let summary = run_dedupe_once(&opts, &vault_dir)?;
             println!(
                 "dedupe complete. duplicate groups: {} files linked: {}",
                 summary.duplicate_groups, summary.files_linked
             );
         }
         Commands::Daemon { command } => match command {
-            DaemonCommand::Run(opts) => run_daemon(opts.dedupe, opts.interval_secs)?,
+            DaemonCommand::Run(opts) => run_daemon(opts.dedupe, opts.interval_secs, &vault_dir)?,
             DaemonCommand::Install(opts) => systemd::install_daemon_service(
                 &opts.target,
                 opts.interval_secs,
@@ -127,22 +143,22 @@ fn run() -> Result<()> {
         },
         Commands::Restore { path, dry_run } => {
             let state = if dry_run {
-                state::State::open_readonly_if_exists()?
+                state::State::open_readonly_if_exists(&vault_dir)?
             } else {
-                state::State::open_default()?
+                state::State::open_default(&vault_dir)?
             };
-            restore_pipeline(&path, &state, dry_run)?;
+            restore_pipeline(&path, &state, dry_run, &vault_dir)?;
         }
     }
 
     Ok(())
 }
 
-fn run_dedupe_once(opts: &DedupeOptions) -> Result<DedupeRunSummary> {
+fn run_dedupe_once(opts: &DedupeOptions, vault_dir: &Path) -> Result<DedupeRunSummary> {
     let state = if opts.dry_run {
-        state::State::open_readonly_if_exists()?
+        state::State::open_readonly_if_exists(vault_dir)?
     } else {
-        state::State::open_default()?
+        state::State::open_default(vault_dir)?
     };
     let groups = scan_pipeline(&opts.path, &state)?;
     dedupe_groups(
@@ -151,10 +167,11 @@ fn run_dedupe_once(opts: &DedupeOptions) -> Result<DedupeRunSummary> {
         opts.paranoid,
         opts.dry_run,
         opts.allow_unsafe_hardlinks,
+        vault_dir,
     )
 }
 
-fn run_daemon(opts: DedupeOptions, interval_secs: u64) -> Result<()> {
+fn run_daemon(opts: DedupeOptions, interval_secs: u64, vault_dir: &Path) -> Result<()> {
     let (shutdown_tx, shutdown_rx) = channel::bounded::<()>(1);
     ctrlc::set_handler(move || {
         let _ = shutdown_tx.try_send(());
@@ -174,7 +191,7 @@ fn run_daemon(opts: DedupeOptions, interval_secs: u64) -> Result<()> {
 
         println!("[daemon] run #{run_no} started");
         let started = std::time::Instant::now();
-        match run_dedupe_once(&opts) {
+        match run_dedupe_once(&opts, vault_dir) {
             Ok(summary) => {
                 println!(
                     "[daemon] run #{run_no} complete in {:.2}s; duplicate_groups={} files_linked={}",
@@ -337,6 +354,7 @@ fn dedupe_groups(
     paranoid: bool,
     dry_run: bool,
     allow_unsafe_hardlinks: bool,
+    vault_dir: &Path,
 ) -> Result<DedupeRunSummary> {
     let mut global_db_ops = Vec::new();
     let mut files_linked = 0usize;
@@ -395,7 +413,7 @@ fn dedupe_groups(
         let master = &paths[0];
 
         let vault_path = if dry_run {
-            let theoretical_path = vault::shard_path(hash)?;
+            let theoretical_path = vault::shard_path(vault_dir, hash);
             let name = display_name(master);
             println!(
                 "{} Would move master: {} -> {}",
@@ -405,7 +423,7 @@ fn dedupe_groups(
             );
             theoretical_path
         } else {
-            vault::ensure_in_vault(hash, master)?
+            vault::ensure_in_vault(vault_dir, hash, master)?
         };
 
         let mut master_verified = false;
@@ -644,7 +662,7 @@ fn print_summary(mode: &str, groups: &HashMap<Hash, Vec<PathBuf>>) {
     println!("{mode} complete. duplicate groups: {duplicates}");
 }
 
-fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<()> {
+fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool, vault_dir: &Path) -> Result<()> {
     let multi = MultiProgress::new();
     let restore_spinner = multi.add(ProgressBar::new_spinner());
     restore_spinner.set_style(
@@ -687,12 +705,12 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
             if let Ok(Some(file_meta)) = state.get_file_metadata(&file_path) {
                 target_hash = Some(file_meta.hash);
             }
-        } else if let Ok(Some(file_meta)) = state.get_file_metadata(&file_path)
-            && let Ok(vault_path) = vault::shard_path(&file_meta.hash)
-            && vault_path.exists()
-        {
-            needs_restore = true;
-            target_hash = Some(file_meta.hash);
+        } else if let Ok(Some(file_meta)) = state.get_file_metadata(&file_path) {
+            let vault_path = vault::shard_path(vault_dir, &file_meta.hash);
+            if vault_path.exists() {
+                needs_restore = true;
+                target_hash = Some(file_meta.hash);
+            }
         }
 
         if needs_restore {
@@ -724,7 +742,7 @@ fn restore_pipeline(path: &Path, state: &state::State, dry_run: bool) -> Result<
                 {
                     current_refcount -= 1;
                     if current_refcount == 0 {
-                        let _ = vault::remove_from_vault(&hash);
+                        let _ = vault::remove_from_vault(vault_dir, &hash);
                         restore_ops.push(DbOp::RemoveCasRefcount(hash));
                         println!(
                             "{}    -> Vault copy pruned (refcount 0)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,13 +26,16 @@ use crate::types::{FileMetadata, Hash};
     version,
     about = "bdstorage: A speed-first, local file deduplication engine.",
     long_about = "bdstorage uses a Tiered Hashing philosophy to minimize I/O overhead:\n\nSize Grouping: Eliminates unique file sizes immediately.\n\nSparse Hashing: Samples 12KB (start/middle/end) to identify candidates.\n\nFull BLAKE3 Hashing: Verifies matches with high-performance 128KB buffering.",
-    help_template = "{before-help}{name} {version}\n{author-with-newline}{about-section}\n\nSTORAGE PATHS (override: --vault-dir or $BDSTORAGE_VAULT):\n  State DB: <vault-dir>/state.redb  (default: ~/.imprint/state.redb)\n  CAS Vault: <vault-dir>/store/     (default: ~/.imprint/store/)\n\n{usage-heading} {usage}\n\nGLOBAL FLAGS:\n  --vault-dir <PATH>   Override vault/state directory (env: BDSTORAGE_VAULT)\n  -h, --help           Print help\n  -V, --version        Print version\n\nSUBCOMMAND FLAGS:\n  --paranoid                 Available on the dedupe subcommand. Forces a byte-for-byte\n                             verification before linking to guarantee 100% collision safety.\n\n  --allow-unsafe-hardlinks   Available on the dedupe subcommand. Allows hard link fallback\n                             when CoW reflinks are not supported. Hard links share the same\n                             inode, so all linked files will have identical metadata.\n\n  -n, --dry-run              Available on dedupe and restore subcommands. Simulates operations\n                             without modifying the filesystem or the database.\n\n{all-args}{after-help}"
+    help_template = "{before-help}{name} {version}\n{author-with-newline}{about-section}\n\nSTORAGE PATHS (override: --vault-dir or $BDSTORAGE_VAULT):\n  State DB: <vault-dir>/state.redb  (default: ~/.imprint/state.redb)\n  CAS Vault: <vault-dir>/store/     (default: ~/.imprint/store/)\n\n{usage-heading} {usage}\n\nGLOBAL FLAGS:\n  --vault-dir <PATH>           Override vault/state directory (env: BDSTORAGE_VAULT)\n  --output-format <text|json>  Set output format (default: text)\n  -h, --help                   Print help\n  -V, --version                Print version\n\nSUBCOMMAND FLAGS:\n  --paranoid                 Available on the dedupe subcommand. Forces a byte-for-byte\n                             verification before linking to guarantee 100% collision safety.\n\n  --allow-unsafe-hardlinks   Available on the dedupe subcommand. Allows hard link fallback\n                             when CoW reflinks are not supported. Hard links share the same\n                             inode, so all linked files will have identical metadata.\n\n  -n, --dry-run              Available on dedupe and restore subcommands. Simulates operations\n                             without modifying the filesystem or the database.\n\n{all-args}{after-help}"
 )]
 struct Cli {
     /// Override the vault and state directory.
     /// Falls back to $BDSTORAGE_VAULT env var, then $HOME/.imprint/.
     #[arg(long, global = true, env = "BDSTORAGE_VAULT")]
     vault_dir: Option<PathBuf>,
+
+    #[arg(long, global = true, value_enum, default_value_t = OutputFormat::Text)]
+    output_format: OutputFormat,
 
     #[command(subcommand)]
     command: Commands,
@@ -103,7 +106,9 @@ fn resolve_vault_dir(cli_override: Option<&Path>) -> Result<PathBuf> {
     match cli_override {
         Some(p) => Ok(p.to_path_buf()),
         None => {
-            let home = std::env::var("HOME").with_context(|| "HOME not set")?;
+            let home = std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .with_context(|| "Neither HOME nor USERPROFILE is set")?;
             Ok(PathBuf::from(home).join(".imprint"))
         }
     }
@@ -119,27 +124,40 @@ fn main() {
 fn run() -> Result<()> {
     let args = Cli::parse();
     let vault_dir = resolve_vault_dir(args.vault_dir.as_deref())?;
+    let mut report = JsonReport::default();
 
     match args.command {
         Commands::Scan { path } => {
             let state = state::State::open_default(&vault_dir)?;
-            let groups = scan_pipeline(&path, &state)?;
-            print_summary("scan", &groups);
+            let groups = scan_pipeline(&path, &state, args.output_format, &mut report)?;
+            if args.output_format == OutputFormat::Text {
+                print_summary("scan", &groups);
+            }
         }
         Commands::Dedupe(opts) => {
-            let summary = run_dedupe_once(&opts, &vault_dir)?;
-            println!(
-                "dedupe complete. duplicate groups: {} files linked: {}",
-                summary.duplicate_groups, summary.files_linked
-            );
+            let summary = run_dedupe_once(&opts, &vault_dir, args.output_format, &mut report)?;
+            if args.output_format == OutputFormat::Text {
+                println!(
+                    "dedupe complete. duplicate groups: {} files linked: {}",
+                    summary.duplicate_groups, summary.files_linked
+                );
+            }
         }
         Commands::Daemon { command } => match command {
             DaemonCommand::Run(opts) => run_daemon(opts.dedupe, opts.interval_secs, &vault_dir)?,
-            DaemonCommand::Install(opts) => systemd::install_daemon_service(
-                &opts.target,
-                opts.interval_secs,
-                opts.allow_unsafe_hardlinks,
-            )?,
+            DaemonCommand::Install(opts) => {
+                #[cfg(not(windows))]
+                systemd::install_daemon_service(
+                    &opts.target,
+                    opts.interval_secs,
+                    opts.allow_unsafe_hardlinks,
+                )?;
+                #[cfg(windows)]
+                {
+                    let _ = opts;
+                    anyhow::bail!("systemd is not supported on Windows");
+                }
+            }
         },
         Commands::Restore { path, dry_run } => {
             let state = if dry_run {

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,16 +26,16 @@ pub struct State {
 
 #[allow(dead_code)]
 impl State {
-    pub fn open_default() -> Result<Self> {
-        Self::open_default_impl(false)
+    pub fn open_default(vault_dir: &Path) -> Result<Self> {
+        Self::open_default_impl(vault_dir, false)
     }
 
-    pub fn open_readonly_if_exists() -> Result<Self> {
-        let db_path = default_db_path()?;
+    pub fn open_readonly_if_exists(vault_dir: &Path) -> Result<Self> {
+        let db_path = db_path(vault_dir);
         if !db_path.exists() {
             return Self::create_dummy();
         }
-        Self::open_default_impl(true)
+        Self::open_default_impl(vault_dir, true)
     }
 
     fn create_dummy() -> Result<Self> {
@@ -55,8 +55,8 @@ impl State {
         })
     }
 
-    fn open_default_impl(readonly: bool) -> Result<Self> {
-        let db_path = default_db_path()?;
+    fn open_default_impl(vault_dir: &Path, readonly: bool) -> Result<Self> {
+        let db_path = db_path(vault_dir);
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("create state directory {:?}", parent))?;
@@ -311,7 +311,6 @@ impl State {
     }
 }
 
-pub fn default_db_path() -> Result<PathBuf> {
-    let home = std::env::var("HOME").with_context(|| "HOME not set")?;
-    Ok(PathBuf::from(home).join(".imprint").join("state.redb"))
+pub fn db_path(vault_dir: &Path) -> PathBuf {
+    vault_dir.join("state.redb")
 }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -29,21 +29,20 @@ impl Drop for TempCleanup {
     }
 }
 
-pub fn vault_root() -> Result<PathBuf> {
-    let home = std::env::var("HOME").with_context(|| "HOME not set")?;
-    Ok(PathBuf::from(home).join(".imprint").join("store"))
+pub fn vault_root(vault_dir: &Path) -> PathBuf {
+    vault_dir.join("store")
 }
 
-pub fn shard_path(hash: &Hash) -> Result<PathBuf> {
+pub fn shard_path(vault_dir: &Path, hash: &Hash) -> PathBuf {
     let hex = hash_to_hex(hash);
     let shard_a = &hex[0..2];
     let shard_b = &hex[2..4];
-    let root = vault_root()?;
-    Ok(root.join(shard_a).join(shard_b).join(hex))
+    let root = vault_root(vault_dir);
+    root.join(shard_a).join(shard_b).join(hex)
 }
 
-pub fn ensure_in_vault(hash: &Hash, src: &Path) -> Result<PathBuf> {
-    let dest = shard_path(hash)?;
+pub fn ensure_in_vault(vault_dir: &Path, hash: &Hash, src: &Path) -> Result<PathBuf> {
+    let dest = shard_path(vault_dir, hash);
     if dest.exists() {
         return Ok(dest);
     }
@@ -81,8 +80,8 @@ pub fn ensure_in_vault(hash: &Hash, src: &Path) -> Result<PathBuf> {
     Ok(dest)
 }
 
-pub fn remove_from_vault(hash: &Hash) -> Result<()> {
-    let dest = shard_path(hash)?;
+pub fn remove_from_vault(vault_dir: &Path, hash: &Hash) -> Result<()> {
+    let dest = shard_path(vault_dir, hash);
     if dest.exists() {
         std::fs::remove_file(&dest).with_context(|| "remove file from vault")?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -392,7 +392,6 @@ fn run_cmd_with_vault_dir(vault_dir: &Path, args: &[&str]) -> assert_cmd::Comman
             })
             .expect("Failed to find bdstorage binary"),
     );
-    // Set HOME to a non-existent path to prove --vault-dir takes precedence
     cmd.env("HOME", "/nonexistent");
     cmd.arg("--vault-dir").arg(vault_dir);
     for arg in args {
@@ -477,3 +476,84 @@ fn test_bdstorage_vault_env_var() {
         "store/ should be in BDSTORAGE_VAULT dir"
     );
 }
+
+#[test]
+fn test_json_output_acceptance() {
+    let temp_dir = setup_env();
+    let home = temp_dir.path();
+    let target = home.join("data");
+    fs::create_dir(&target).expect("Failed to create target directory");
+
+    create_file_with_content(&target, "file1.txt", b"1234");
+    create_file_with_content(&target, "file2.txt", b"1234");
+
+    let mut cmd = run_cmd(
+        home,
+        &[
+            "--output-format",
+            "json",
+            "dedupe",
+            &target.to_string_lossy(),
+            "--allow-unsafe-hardlinks",
+        ],
+    );
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let json_str = String::from_utf8_lossy(&output);
+    let json: serde_json::Value =
+        serde_json::from_str(&json_str).expect("Failed to parse dedupe JSON output");
+
+    assert_eq!(json["files_scanned"], 2);
+    assert_eq!(json["duplicate_groups"], 1);
+    assert_eq!(json["bytes_saved"], 4);
+    assert_eq!(json["links_created"], 2);
+    assert_eq!(json["vault_objects_added"], 1);
+
+    let scan_target = home.join("scan_data");
+    fs::create_dir(&scan_target).expect("Failed to create scan target directory");
+    create_file_with_content(&scan_target, "scan1.txt", b"scan duplicate");
+    create_file_with_content(&scan_target, "scan2.txt", b"scan duplicate");
+
+    let mut cmd_scan = run_cmd(
+        home,
+        &[
+            "--output-format",
+            "json",
+            "scan",
+            &scan_target.to_string_lossy(),
+        ],
+    );
+    let output_scan = cmd_scan.assert().success().get_output().stdout.clone();
+    let json_scan_str = String::from_utf8_lossy(&output_scan);
+    let json_scan: serde_json::Value =
+        serde_json::from_str(&json_scan_str).expect("Failed to parse scan JSON output");
+
+    assert_eq!(json_scan["files_scanned"], 2);
+    assert_eq!(json_scan["duplicate_groups"], 1);
+
+    let dry_run_target = home.join("dry_run_data");
+    fs::create_dir(&dry_run_target).expect("Failed to create dry-run target directory");
+    create_file_with_content(&dry_run_target, "dry1.txt", b"1234");
+    create_file_with_content(&dry_run_target, "dry2.txt", b"1234");
+
+    let mut cmd_dry = run_cmd(
+        home,
+        &[
+            "--output-format",
+            "json",
+            "dedupe",
+            &dry_run_target.to_string_lossy(),
+            "--dry-run",
+        ],
+    );
+    let output_dry = cmd_dry.assert().success().get_output().stdout.clone();
+    let json_dry_str = String::from_utf8_lossy(&output_dry);
+    let json_dry: serde_json::Value =
+        serde_json::from_str(&json_dry_str).expect("Failed to parse dry-run JSON output");
+
+    assert_eq!(json_dry["files_scanned"], 2);
+    assert_eq!(json_dry["duplicate_groups"], 1);
+    assert_eq!(json_dry["bytes_saved"], 4);
+    assert_eq!(json_dry["links_created"], 2);
+    assert_eq!(json_dry["vault_objects_added"], 0);
+}
+

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -377,3 +377,103 @@ fn test_dry_run_no_changes() {
         "Entire .imprint directory (vault and database) must not exist in dry-run mode"
     );
 }
+
+fn run_cmd_with_vault_dir(vault_dir: &Path, args: &[&str]) -> assert_cmd::Command {
+    let mut cmd = Command::new(
+        std::env::current_exe()
+            .ok()
+            .map(|mut exe| {
+                exe.pop();
+                if exe.ends_with("deps") {
+                    exe.pop();
+                }
+                exe.push("bdstorage");
+                exe
+            })
+            .expect("Failed to find bdstorage binary"),
+    );
+    // Set HOME to a non-existent path to prove --vault-dir takes precedence
+    cmd.env("HOME", "/nonexistent");
+    cmd.arg("--vault-dir").arg(vault_dir);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd
+}
+
+#[test]
+fn test_vault_dir_flag_dedupe_and_restore() {
+    let data_tmp = setup_env();
+    let vault_tmp = setup_env();
+
+    let target = data_tmp.path().join("data");
+    fs::create_dir(&target).expect("create target dir");
+
+    for i in 0..3 {
+        create_file_with_content(&target, &format!("dup_{}.txt", i), b"vault-dir test content");
+    }
+
+    let mut dedupe_cmd = run_cmd_with_vault_dir(
+        vault_tmp.path(),
+        &["dedupe", &target.to_string_lossy(), "--allow-unsafe-hardlinks"],
+    );
+    dedupe_cmd.assert().success();
+
+    assert!(
+        vault_tmp.path().join("state.redb").exists(),
+        "state.redb should be in custom vault dir"
+    );
+    assert!(
+        vault_tmp.path().join("store").exists(),
+        "store/ should be in custom vault dir"
+    );
+
+    let mut restore_cmd = run_cmd_with_vault_dir(
+        vault_tmp.path(),
+        &["restore", &target.to_string_lossy()],
+    );
+    restore_cmd.assert().success();
+
+    let content = fs::read(target.join("dup_0.txt")).expect("read restored file");
+    assert_eq!(content, b"vault-dir test content");
+}
+
+#[test]
+fn test_bdstorage_vault_env_var() {
+    let data_tmp = setup_env();
+    let vault_tmp = setup_env();
+
+    let target = data_tmp.path().join("data");
+    fs::create_dir(&target).expect("create target dir");
+
+    for i in 0..3 {
+        create_file_with_content(&target, &format!("dup_{}.txt", i), b"env var test content");
+    }
+
+    let mut cmd = Command::new(
+        std::env::current_exe()
+            .ok()
+            .map(|mut exe| {
+                exe.pop();
+                if exe.ends_with("deps") {
+                    exe.pop();
+                }
+                exe.push("bdstorage");
+                exe
+            })
+            .expect("Failed to find bdstorage binary"),
+    );
+    cmd.env("HOME", "/nonexistent");
+    cmd.env("BDSTORAGE_VAULT", vault_tmp.path());
+    cmd.args(["dedupe", &target.to_string_lossy(), "--allow-unsafe-hardlinks"]);
+    cmd.assert().success();
+
+    assert!(
+        vault_tmp.path().join("state.redb").exists(),
+        "state.redb should be in BDSTORAGE_VAULT dir"
+    );
+    assert!(
+        vault_tmp.path().join("store").exists(),
+        "store/ should be in BDSTORAGE_VAULT dir"
+    );
+}


### PR DESCRIPTION
Closes #45

### Problem
The vault and state DB were hardcoded to `$HOME/.imprint/`, making it
impossible to use a separate drive, run multiple vaults, or use bdstorage
in CI where `$HOME` is ephemeral.

### Solution
- Added `--vault-dir <PATH>` global CLI flag (parsed before subcommand dispatch)
- Added `BDSTORAGE_VAULT` env var as fallback (handled via clap's `env` attribute)
- `$HOME/.imprint/` remains the default when neither override is set
- Threaded the resolved vault dir through `vault.rs` and `state.rs` as a `&Path` parameter
- Updated the `Data Locations & Storage` section of `README.md`
- Added integration tests for both the CLI flag and env var

### Priority Order
`--vault-dir` flag → `BDSTORAGE_VAULT` env var → `$HOME/.imprint/` (default)
