### PR TITLE
docs: add verification step for restore command

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ bdstorage restore /path/to/directory
 |:---|:---|
 | `-n`, `--dry-run` | Show what would be restored without writing. |
 
+> **Verification:** After running `restore`, verify that restored files are no longer linked by checking their link count with `ls -l`. Restored files should have a link count of `1`, indicating they are independent copies.
+
 When a vault object’s refcount hits zero during restore, it is **removed** (garbage collection).
 
 **Status** (passive vault inspection):


### PR DESCRIPTION
## Description

Added a verification note to the `restore` section of the README explaining how to confirm that restored files are no longer linked by checking their link count. This provides contributors with a simple way to verify that the restore operation completed successfully.

Fixes #None (documentation improvement)